### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # v1
+        uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # v1.5.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -33,10 +33,10 @@ jobs:
             registry.yarnpkg.com:443
 
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup
-        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v2
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           node-version: lts/gallium
           cache: yarn
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # v1
+        uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # v1.5.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -66,16 +66,16 @@ jobs:
             uploads.github.com:443
 
       - name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v1
+        uses: github/codeql-action/init@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v2.1.31
         with:
           languages: javascript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v1
+        uses: github/codeql-action/analyze@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v2.1.31
 
   build:
     needs:
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # v1
+        uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # v1.5.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -98,12 +98,12 @@ jobs:
             registry.yarnpkg.com:443
 
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           token: ${{ secrets.DEPLOY_TOKEN }}
 
       - name: Setup
-        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v2
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           node-version: lts/gallium
           cache: yarn

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,10 +26,8 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
             codeload.github.com:443
             github.com:443
-            kv4gacprodeus2file3.blob.core.windows.net:443
             registry.yarnpkg.com:443
 
       - name: Checkout
@@ -61,8 +59,8 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
-            github.com:443
             codeload.github.com:443
+            github.com:443
             uploads.github.com:443
 
       - name: Checkout repository
@@ -91,10 +89,8 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
             codeload.github.com:443
             github.com:443
-            kv4gacprodeus2file3.blob.core.windows.net:443
             registry.yarnpkg.com:443
 
       - name: Checkout

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # v1
+        uses: step-security/harden-runner@2e205a28d0e1da00c5f53b161f4067b052c61f34 # v1.5.0
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -6,7 +6,7 @@ on:
     - cron: '29 3 * * 4'
   push:
     branches:
-    - main
+      - main
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -22,13 +22,13 @@ jobs:
       contents: read
 
     steps:
-      - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v2.4.0
+      - name: Checkout code
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           persist-credentials: false
 
-      - name: "Run analysis"
-        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v1.0.2
+      - name: Run analysis
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
         with:
           results_file: results.sarif
           results_format: sarif
@@ -42,15 +42,15 @@ jobs:
           publish_results: true
 
       # Upload the results as artifacts (optional).
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v2.3.1
+      - name: Upload artifact
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v1.0.26
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@c3b6fce4ee2ca25bc1066aa3bf73962fda0e8898 # v2.1.31
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -18,6 +18,9 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
+      # Used for sharing results with the securityscorecards.dev API
+      # (publish_results: true)
+      id-token: write
       actions: read
       contents: read
 


### PR DESCRIPTION
Clean up CI steps and fix the scorecard workflow:

- CI: Update the version comment for all actions
- CI: Remove cache hosts from allowed endpoints
- CI: Add permission needed by scorecard action
