### PR TITLE
ci: Use latest node LTS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: lts/gallium
+          node-version: 'lts/*'
           cache: yarn
 
       - name: Install
@@ -101,7 +101,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: lts/gallium
+          node-version: 'lts/*'
           cache: yarn
 
       - name: Install


### PR DESCRIPTION
This should unbreak the CI workflows as semantic-release now requires Node 18 or up.
