### PR TITLE
refactor: clean up private identifier names

### DIFF
--- a/scripts/connected-users/src/users/classes.ts
+++ b/scripts/connected-users/src/users/classes.ts
@@ -54,7 +54,7 @@ export class ExistingUser extends User {
     | 'team_admin'
     | 'does_not_exist'
 
-  private get _badges(): string {
+  private get badges(): string {
     const badges = []
     if (this.is_employee) {
       badges.push(
@@ -84,7 +84,7 @@ export class ExistingUser extends User {
     return user
   }
 
-  private get _abbreviated_reputation(): string {
+  private get abbreviatedReputation(): string {
     return this.reputation < 10000
       ? fullRepFormat.format(this.reputation)
       : abbreviatedRepFormat.format(this.reputation).toLowerCase()
@@ -100,14 +100,14 @@ export class ExistingUser extends User {
         </a>
         <div class="s-user-card--info">
           <a href="${this.link}" class="s-user-card--link"
-            >${escapeHtml(this.display_name)} ${this._badges}</a
+            >${escapeHtml(this.display_name)} ${this.badges}</a
           >
           <ul class="s-user-card--awards">
             <li
               class="s-user-card--rep"
               title="reputation score ${fullRepFormat.format(this.reputation)}"
             >
-              ${this._abbreviated_reputation}
+              ${this.abbreviatedReputation}
             </li>
             <li class="s-award-bling s-award-bling__gold">${
               this.badge_counts.gold

--- a/scripts/connected-users/src/xrefIPAddresses/controller.ts
+++ b/scripts/connected-users/src/xrefIPAddresses/controller.ts
@@ -212,10 +212,10 @@ export class XRefConnectedUsersController extends Stacks.StacksController {
     IpGroupController.controllerId,
   ]
 
-  private get _ipGroups(): IpGroupController[] {
+  private get ipGroups(): IpGroupController[] {
     return this[outlets<this>(IpGroupController)] as IpGroupController[]
   }
-  private get _histogram(): HistogramController {
+  private get histogram(): HistogramController {
     return this[outlet<this>(HistogramController)] as HistogramController
   }
 
@@ -294,9 +294,9 @@ export class XRefConnectedUsersController extends Stacks.StacksController {
     )
   }
 
-  private _threshold = 0
+  private threshold = 0
 
-  private get _uiDiv(): HTMLDivElement {
+  private get uiDiv(): HTMLDivElement {
     let uiDiv = this.element.querySelector<HTMLDivElement>(
       `.s-${this.identifier}`
     )
@@ -325,9 +325,9 @@ export class XRefConnectedUsersController extends Stacks.StacksController {
     return uiDiv
   }
 
-  private get _connectedUsers(): UserFrequencies {
+  private get connectedUsers(): UserFrequencies {
     const connectedUsers: Map<number, number> = new Map()
-    this._ipGroups.forEach((ipGroup) =>
+    this.ipGroups.forEach((ipGroup) =>
       ipGroup.connectedUsers.forEach((uid) =>
         connectedUsers.set(uid, (connectedUsers.get(uid) ?? 0) + 1)
       )
@@ -340,30 +340,30 @@ export class XRefConnectedUsersController extends Stacks.StacksController {
   }
 
   connect(): void {
-    this.element.insertAdjacentElement('afterbegin', this._uiDiv)
-    this._updateConnectedUsersList(this._connectedUsers)
-    this._updateFocusedUsersList()
+    this.element.insertAdjacentElement('afterbegin', this.uiDiv)
+    this.updateConnectedUsersList(this.connectedUsers)
+    this.updateFocusedUsersList()
   }
 
   [outletConnected(HistogramController)](outlet: HistogramController): void {
-    outlet.setFrequencies(this._connectedUsers)
+    outlet.setFrequencies(this.connectedUsers)
   }
 
   reloadPreferences() {
     reloadPreferences()
-    this._refresh()
+    this.refresh()
   }
 
   showConnected({ detail: { connCount } }: { detail: Bucket }): void {
-    if (connCount !== this._threshold) {
-      this._threshold = connCount
-      this._refreshConnectedUsers(this._connectedUsers)
+    if (connCount !== this.threshold) {
+      this.threshold = connCount
+      this.refreshConnectedUsers(this.connectedUsers)
     }
   }
 
   toggleOnly({ target }: { target: HTMLInputElement }): void {
     preferences.xrefUIState.showOnlyConnected = target.checked
-    this._ipGroups.forEach((ipGroup) => ipGroup.refresh(target.checked))
+    this.ipGroups.forEach((ipGroup) => ipGroup.refresh(target.checked))
   }
 
   sectionToggled({ target }: { target: HTMLElement }): void {
@@ -378,7 +378,7 @@ export class XRefConnectedUsersController extends Stacks.StacksController {
     preferences.focusedUsers = Array.from(
       new Set([...preferences.focusedUsers, uid])
     ).sort((a, b) => a - b)
-    if (preferences.focusedUsers.length !== before) this._refresh()
+    if (preferences.focusedUsers.length !== before) this.refresh()
   }
 
   removeFocusUser({ params: { uid } }: { params: { uid: number } }): void {
@@ -386,14 +386,14 @@ export class XRefConnectedUsersController extends Stacks.StacksController {
     preferences.focusedUsers = preferences.focusedUsers.filter(
       (focusedUid) => focusedUid !== uid
     )
-    if (preferences.focusedUsers.length !== before) this._refresh()
+    if (preferences.focusedUsers.length !== before) this.refresh()
   }
 
   clearFocusUsers(): void {
     if (!confirm('Clear all focused users?')) return
     if (preferences.focusedUsers.length > 0) {
       preferences.focusedUsers = []
-      this._refresh()
+      this.refresh()
     }
   }
 
@@ -427,33 +427,33 @@ export class XRefConnectedUsersController extends Stacks.StacksController {
     graphLink.href = url.toString()
   }
 
-  _refreshId: number | null = null
+  private refreshId: number | null = null
 
-  private _refresh(): void {
-    if (this._refreshId !== null) return
-    this._refreshId = window.requestAnimationFrame(() => {
-      this._threshold = 0
-      this._updateFocusedUsersList()
-      const connectedUsers = this._connectedUsers
-      this._histogram.setFrequencies(connectedUsers, false)
-      this._refreshConnectedUsers(connectedUsers)
-      this._refreshId = null
+  private refresh(): void {
+    if (this.refreshId !== null) return
+    this.refreshId = window.requestAnimationFrame(() => {
+      this.threshold = 0
+      this.updateFocusedUsersList()
+      const connectedUsers = this.connectedUsers
+      this.histogram.setFrequencies(connectedUsers, false)
+      this.refreshConnectedUsers(connectedUsers)
+      this.refreshId = null
     })
   }
 
-  private _refreshConnectedUsers(connectedUsers: UserFrequencies): void {
-    this._ipGroups.forEach((ipGroup) =>
-      ipGroup.updateUsersBelowThreshold(this._threshold, connectedUsers)
+  private refreshConnectedUsers(connectedUsers: UserFrequencies): void {
+    this.ipGroups.forEach((ipGroup) =>
+      ipGroup.updateUsersBelowThreshold(this.threshold, connectedUsers)
     )
-    this._updateConnectedUsersList(connectedUsers)
+    this.updateConnectedUsersList(connectedUsers)
   }
 
-  private _updateConnectedUsersList(connectedUsers: UserFrequencies): void {
+  private updateConnectedUsersList(connectedUsers: UserFrequencies): void {
     const doUpdate = () => {
       const connectedUsersDiv = this.connectedUsersTarget
       connectedUsersDiv.replaceChildren()
       connectedUsers.forEach(({ uid, count }) => {
-        if (count < this._threshold) return
+        if (count < this.threshold) return
         const overlap = `Overlaps on ${count} IP${count !== 1 ? 's' : ''}`
         connectedUsersDiv.insertAdjacentHTML(
           'beforeend',
@@ -485,12 +485,12 @@ export class XRefConnectedUsersController extends Stacks.StacksController {
       })
     }
     // if already contained in an animationFrame handler, run directly.
-    this._refreshId === null
+    this.refreshId === null
       ? window.requestAnimationFrame(doUpdate)
       : doUpdate()
   }
 
-  private _updateFocusedUsersList(): void {
+  private updateFocusedUsersList(): void {
     const focusedUsersDiv = this.focusedUsersTarget
     focusedUsersDiv.replaceChildren()
     preferences.focusedUsers.forEach((uid) => {

--- a/scripts/connected-users/src/xrefIPAddresses/ipGroup.ts
+++ b/scripts/connected-users/src/xrefIPAddresses/ipGroup.ts
@@ -84,38 +84,38 @@ export class IpGroupController extends Stacks.StacksController {
     )
   }
 
-  private _belowThreshold: Set<number>
+  private belowThreshold: Set<number>
 
-  private get _userRows(): HTMLTableRowElement[] {
+  private get userRows(): HTMLTableRowElement[] {
     return Array.from(
       this.element.querySelectorAll<HTMLTableRowElement>('tbody > tr[data-uid]')
     )
   }
 
-  private get _mainUserRow(): HTMLTableRowElement {
+  private get mainUserRow(): HTMLTableRowElement {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return this.element.querySelector<HTMLTableRowElement>(
       `tbody .${mainUserCls}`
     )!
   }
 
-  private get _focusUserRows(): HTMLTableRowElement[] {
+  private get focusUserRows(): HTMLTableRowElement[] {
     const known = new Set<number>(preferences.focusedUsers)
-    return this._userRows.filter((tr) =>
+    return this.userRows.filter((tr) =>
       known.has(parseInt(tr.dataset.uid || '0'))
     )
   }
 
-  private get _focusIntervals(): luxon.Interval[] {
-    return [this._mainUserRow, ...this._focusUserRows].map((tr) =>
+  private get focusIntervals(): luxon.Interval[] {
+    return [this.mainUserRow, ...this.focusUserRows].map((tr) =>
       parseAccessInterval(tr)
     )
   }
 
-  private get _connectedUserRows(): HTMLTableRowElement[] {
-    const intervals = this._focusIntervals
+  private get connectedUserRows(): HTMLTableRowElement[] {
+    const intervals = this.focusIntervals
     const known = new Set<number>(preferences.focusedUsers)
-    return this._userRows.filter((tr) => {
+    return this.userRows.filter((tr) => {
       if (tr.classList.contains(mainUserCls)) return false
       const uid = parseInt(tr.dataset.uid || '0')
       if (known.has(uid)) return false
@@ -125,12 +125,12 @@ export class IpGroupController extends Stacks.StacksController {
   }
 
   get connectedUsers(): number[] {
-    return this._connectedUserRows.map((tr) => parseInt(tr.dataset.uid || '0'))
+    return this.connectedUserRows.map((tr) => parseInt(tr.dataset.uid || '0'))
   }
 
-  _showOnlyConnected: boolean
+  private showOnlyConnected: boolean
 
-  private _updateMarkup() {
+  private updateMarkup() {
     // Make it easier to work with the table rows by adding some dataset values.
     this.element
       .querySelectorAll<HTMLTableRowElement>('tbody tr')
@@ -145,15 +145,15 @@ export class IpGroupController extends Stacks.StacksController {
   }
 
   connect() {
-    this._updateMarkup()
-    this._belowThreshold = new Set<number>()
-    this._showOnlyConnected = preferences.xrefUIState.showOnlyConnected
-    this._addFocusButtons()
-    this._updateClasses()
+    this.updateMarkup()
+    this.belowThreshold = new Set<number>()
+    this.showOnlyConnected = preferences.xrefUIState.showOnlyConnected
+    this.addFocusButtons()
+    this.updateClasses()
   }
 
-  private _addFocusButtons() {
-    this._userRows.forEach((tr) => {
+  private addFocusButtons() {
+    this.userRows.forEach((tr) => {
       const uid = tr.dataset.uid || '0'
       const dataKey = `${camelize(controllerId)}UidParam`
       tr.querySelector('td a')?.insertAdjacentHTML('beforebegin', userControls)
@@ -163,46 +163,46 @@ export class IpGroupController extends Stacks.StacksController {
     })
   }
 
-  private _updateClasses() {
-    this._userRows.forEach((tr) => {
+  private updateClasses() {
+    this.userRows.forEach((tr) => {
       tr.classList.remove(knownUserCls, overlapCls, 'd-none')
       delete tr.dataset.connected
     })
-    this._focusUserRows.forEach((tr) => {
+    this.focusUserRows.forEach((tr) => {
       tr.classList.add(knownUserCls)
     })
-    this._connectedUserRows.forEach((tr) => {
+    this.connectedUserRows.forEach((tr) => {
       const uid = parseInt(tr.dataset.uid || '0')
-      tr.classList.toggle(overlapCls, !this._belowThreshold.has(uid))
+      tr.classList.toggle(overlapCls, !this.belowThreshold.has(uid))
     })
-    if (this._showOnlyConnected) {
+    if (this.showOnlyConnected) {
       const kept = [mainUserCls, knownUserCls, overlapCls]
-      this._userRows.forEach((tr) => {
+      this.userRows.forEach((tr) => {
         if (!kept.some((c) => tr.classList.contains(c)))
           tr.classList.add('d-none')
       })
     }
   }
 
-  _refreshId: number | null = null
+  private refreshId: number | null = null
 
   refresh(showOnlyConnected?: boolean) {
     if (showOnlyConnected !== undefined)
-      this._showOnlyConnected = showOnlyConnected
-    if (this._refreshId !== null) return
-    this._refreshId = window.requestAnimationFrame(() => {
-      this._updateClasses()
-      this._refreshId = null
+      this.showOnlyConnected = showOnlyConnected
+    if (this.refreshId !== null) return
+    this.refreshId = window.requestAnimationFrame(() => {
+      this.updateClasses()
+      this.refreshId = null
     })
   }
 
   updateUsersBelowThreshold(threshold: number, connected: UserFrequencies) {
-    this._belowThreshold = new Set<number>(
+    this.belowThreshold = new Set<number>(
       connected.reduce(
         (uids, { uid, count }) => (count < threshold ? [...uids, uid] : uids),
         [] as number[]
       )
     )
-    this._updateClasses()
+    this.updateClasses()
   }
 }

--- a/utils/scripts.ts
+++ b/utils/scripts.ts
@@ -21,34 +21,34 @@ class UserScripts {
     return Object.keys(this.entries)
   }
 
-  private _entries: { [key: string]: string } | undefined
+  private entries_cache: { [key: string]: string } | undefined
 
   get entries(): { [key: string]: string } {
-    if (this._entries === undefined) {
+    if (this.entries_cache === undefined) {
       const scriptMainPaths = glob.globIterateSync(
         path.join(this.scriptsFolder, '*/src/index.ts')
       )
-      this._entries = {}
+      this.entries_cache = {}
       for (const mainPath of scriptMainPaths) {
         const scriptName = path.basename(path.dirname(path.dirname(mainPath)))
-        this._entries[scriptName] = mainPath
+        this.entries_cache[scriptName] = mainPath
       }
     }
-    return this._entries
+    return this.entries_cache
   }
 
-  private _headers: UserScriptContexts
+  private headers_cache: UserScriptContexts
 
   get headers(): UserScriptContexts {
-    if (this._headers === undefined) {
-      this._headers = {}
+    if (this.headers_cache === undefined) {
+      this.headers_cache = {}
       for (const scriptName of Object.keys(this.entries)) {
-        Object.defineProperty(this._headers, scriptName, {
+        Object.defineProperty(this.headers_cache, scriptName, {
           get: () => this.headersFor(scriptName),
         })
       }
     }
-    return this._headers
+    return this.headers_cache
   }
 
   private headersFor(scriptName: string): Record<string, any> {
@@ -64,17 +64,18 @@ class UserScripts {
     }
   }
 
-  private _tests: UserScriptTest[]
+  private tests_cache: UserScriptTest[]
+
   get tests(): UserScriptTest[] {
-    if (this._tests === undefined) {
-      this._tests = this.names.reduce((tests, scriptName) => {
+    if (this.tests_cache === undefined) {
+      this.tests_cache = this.names.reduce((tests, scriptName) => {
         const scriptPath = path.resolve(this.scriptsFolder, scriptName)
         if (existsSync(path.resolve(scriptPath, 'test')))
           tests = [...tests, { name: scriptName, path: scriptPath }]
         return tests
       }, [] as UserScriptTest[])
     }
-    return this._tests
+    return this.tests_cache
   }
 }
 


### PR DESCRIPTION
The initial underscore is a Python hold-over. Properly mark things as
private and use camelCase throughout.
