### PR TITLE
Fix histogram pointer event handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@semantic-release/git": "^10.0.1",
     "@swc/core": "^1.3.46",
     "@swc/jest": "^0.2.24",
+    "@testing-library/dom": "^9.2.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/node": "^18.15.11",
     "@types/semantic-release": "^20.0.1",
     "@types/ssri": "^7.1.1",

--- a/scripts/connected-users/src/xrefIPAddresses/histogram.ts
+++ b/scripts/connected-users/src/xrefIPAddresses/histogram.ts
@@ -112,12 +112,18 @@ export class HistogramController extends Stacks.StacksController {
 
   connect() {
     this.svgTarget.addEventListener('click', this.propagateEvent.bind(this))
-    this.svgTarget.addEventListener('hover', this.propagateEvent.bind(this))
+    this.svgTarget.addEventListener(
+      'pointerover',
+      this.propagateEvent.bind(this)
+    )
   }
 
   disconnect() {
     this.svgTarget.removeEventListener('click', this.propagateEvent.bind(this))
-    this.svgTarget.removeEventListener('hover', this.propagateEvent.bind(this))
+    this.svgTarget.removeEventListener(
+      'pointerover',
+      this.propagateEvent.bind(this)
+    )
   }
 
   private svgRatioCache: number
@@ -141,11 +147,16 @@ export class HistogramController extends Stacks.StacksController {
   }
 
   private propagateEvent(e: Event): void {
-    const target = e.target as SVGRectElement
-    const index = target.dataset.bucketIndex
-    if (index === undefined) return
+    const bucketRect = (e.target as SVGElement | null)?.closest(
+      'svg [data-bucket-index]'
+    ) as SVGElement | null
+    const indexStr = bucketRect?.dataset.bucketIndex
+    if (indexStr === undefined) return
+    const index = parseInt(indexStr)
+    if (index < 0 || index >= this.buckets.length) return
+    e.stopPropagation()
 
-    const bucket = this.buckets[parseInt(index)]
+    const bucket = this.buckets[index]
     if (e.type === 'click') this.adjustThresholdClasses(bucket.connCount)
 
     this.dispatch(e.type, { detail: bucket })

--- a/scripts/connected-users/test/testUtils.ts
+++ b/scripts/connected-users/test/testUtils.ts
@@ -20,3 +20,9 @@ export const cartesian = <T extends unknown[][]>(inputs: [...T]) => {
     }
   }
 }
+
+export const domReady = () =>
+  new Promise<void>((resolve) => {
+    if (document.readyState !== 'loading') return resolve()
+    document.addEventListener('DOMContentLoaded', () => resolve())
+  })

--- a/scripts/connected-users/test/xrefIPAddresses/__snapshots__/histogram.test.ts.snap
+++ b/scripts/connected-users/test/xrefIPAddresses/__snapshots__/histogram.test.ts.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The histogram controller dispatches a click event for the first bucket whenever more than 1 bucket is present 1`] = `"<svg xmlns="http://www.w3.org/2000/svg" data-us-mod-connected-users-histogram-target="svg"></svg>"`;
+
+exports[`The histogram controller dispatches a click event for the first bucket whenever more than 1 bucket is present 2`] = `
+"<svg xmlns="http://www.w3.org/2000/svg" data-us-mod-connected-users-histogram-target="svg" viewBox="0 0 21 10.152892561983471"><g stroke-width="0.05076446280991736" class="gridLines">
+        <defs><line id="gridLine" x1="0" x2="21" y1="0" y2="0"></line></defs>
+        <use href="#gridLine"></use>
+       <use href="#gridLine" y="10.152892561983471"></use><use href="#gridLine" y="6.768595041322314"></use><use href="#gridLine" y="3.384297520661157"></use></g>
+        <rect width="4" height="10.152892561983471" x="1" y="0" data-bucket-index="0" data-bucket-conn-count="2" class="threshold">
+          <title>Overlapping on 2 ips: 3 accounts</title>
+        </rect>
+       
+        <rect width="4" height="0" x="6" y="10.152892561983471" data-bucket-index="1" data-bucket-conn-count="3">
+          <title>Overlapping on 3 ips: 0 accounts</title>
+        </rect>
+       
+        <rect width="4" height="0" x="11" y="10.152892561983471" data-bucket-index="2" data-bucket-conn-count="4">
+          <title>Overlapping on 4 ips: 0 accounts</title>
+        </rect>
+       
+        <rect width="4" height="6.768595041322314" x="16" y="3.384297520661157" data-bucket-index="3" data-bucket-conn-count="5">
+          <title>Overlapping on 5 ips: 2 accounts</title>
+        </rect>
+       </svg>"
+`;
+
+exports[`The histogram controller renders the histogram whenever frequencies are set 1`] = `"<svg xmlns="http://www.w3.org/2000/svg" data-us-mod-connected-users-histogram-target="svg"></svg>"`;
+
+exports[`The histogram controller renders the histogram whenever frequencies are set 2`] = `
+"<svg xmlns="http://www.w3.org/2000/svg" data-us-mod-connected-users-histogram-target="svg" viewBox="0 0 21 10.152892561983471"><g stroke-width="0.05076446280991736" class="gridLines">
+        <defs><line id="gridLine" x1="0" x2="21" y1="0" y2="0"></line></defs>
+        <use href="#gridLine"></use>
+       <use href="#gridLine" y="10.152892561983471"></use><use href="#gridLine" y="6.768595041322314"></use><use href="#gridLine" y="3.384297520661157"></use></g>
+        <rect width="4" height="10.152892561983471" x="1" y="0" data-bucket-index="0" data-bucket-conn-count="2" class="threshold">
+          <title>Overlapping on 2 ips: 3 accounts</title>
+        </rect>
+       
+        <rect width="4" height="0" x="6" y="10.152892561983471" data-bucket-index="1" data-bucket-conn-count="3">
+          <title>Overlapping on 3 ips: 0 accounts</title>
+        </rect>
+       
+        <rect width="4" height="0" x="11" y="10.152892561983471" data-bucket-index="2" data-bucket-conn-count="4">
+          <title>Overlapping on 4 ips: 0 accounts</title>
+        </rect>
+       
+        <rect width="4" height="6.768595041322314" x="16" y="3.384297520661157" data-bucket-index="3" data-bucket-conn-count="5">
+          <title>Overlapping on 5 ips: 2 accounts</title>
+        </rect>
+       </svg>"
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.10.4":
+  version: 7.21.4
+  resolution: "@babel/code-frame@npm:7.21.4"
+  dependencies:
+    "@babel/highlight": ^7.18.6
+  checksum: e5390e6ec1ac58dcef01d4f18eaf1fd2f1325528661ff6d4a5de8979588b9f5a8e852a54a91b923846f7a5c681b217f0a45c2524eb9560553160cd963b7d592c
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.20.5":
   version: 7.21.0
   resolution: "@babel/compat-data@npm:7.21.0"
@@ -360,6 +369,15 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 6189c0b5c32ba3c9a80a42338bd50719d783b20ef29b853d4f03929e971913d3cefd80184e924ae98ad6db09080be8fe6f1ffde9a6db8972523234f0274d36f7
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.12.5":
+  version: 7.21.0
+  resolution: "@babel/runtime@npm:7.21.0"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 7b33e25bfa9e0e1b9e8828bb61b2d32bdd46b41b07ba7cb43319ad08efc6fda8eb89445193e67d6541814627df0ca59122c0ea795e412b99c5183a0540d338ab
   languageName: node
   linkType: hard
 
@@ -1752,6 +1770,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "@testing-library/dom@npm:9.2.0"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^5.0.1
+    aria-query: ^5.0.0
+    chalk: ^4.1.0
+    dom-accessibility-api: ^0.5.9
+    lz-string: ^1.5.0
+    pretty-format: ^27.0.2
+  checksum: b145f43cd06ff083012cf2503aff6ccba97ff80715fcb106fe64af690f5536557bf24d37b97e8d685bbe3803d7f71d685ce71426cb1b9e250c3611e4372dcfa9
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^14.4.3":
+  version: 14.4.3
+  resolution: "@testing-library/user-event@npm:14.4.3"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 852c48ea6db1c9471b18276617c84fec4320771e466cd58339a732ca3fd73ad35e5a43ae14f51af51a8d0a150dcf60fcaab049ef367871207bea8f92c4b8195e
+  languageName: node
+  linkType: hard
+
 "@tootallnate/once@npm:2":
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
@@ -1793,6 +1836,13 @@ __metadata:
   dependencies:
     minimatch: ^7.4.2
   checksum: 2f8ebc8e8ef56be67051077b09c7611f50e04d89f8277e3ab518565fbbdf5c81e725c66ae3793cdcc9ec443eb1229dccc3af5d96ec71a134e4c00ea749733bcd
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@types/aria-query@npm:5.0.1"
+  checksum: 69fd7cceb6113ed370591aef04b3fd0742e9a1b06dd045c43531448847b85de181495e4566f98e776b37c422a12fd71866e0a1dfd904c5ec3f84d271682901de
   languageName: node
   linkType: hard
 
@@ -2955,6 +3005,15 @@ __metadata:
   version: 1.0.0
   resolution: "argv-formatter@npm:1.0.0"
   checksum: cf95ea091f4eb0fefdbbc595dbe2e307afee16fc87aad48d72e5e45d5b0b59566dbaa77e45d515242289670904838a501313efffb48ff02f49c6de0c03536a54
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:^5.0.0":
+  version: 5.1.3
+  resolution: "aria-query@npm:5.1.3"
+  dependencies:
+    deep-equal: ^2.0.5
+  checksum: 929ff95f02857b650fb4cbcd2f41072eee2f46159a6605ea03bf63aa572e35ffdff43d69e815ddc462e16e07de8faba3978afc2813650b4448ee18c9895d982b
   languageName: node
   linkType: hard
 
@@ -4155,6 +4214,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-equal@npm:^2.0.5":
+  version: 2.2.0
+  resolution: "deep-equal@npm:2.2.0"
+  dependencies:
+    call-bind: ^1.0.2
+    es-get-iterator: ^1.1.2
+    get-intrinsic: ^1.1.3
+    is-arguments: ^1.1.1
+    is-array-buffer: ^3.0.1
+    is-date-object: ^1.0.5
+    is-regex: ^1.1.4
+    is-shared-array-buffer: ^1.0.2
+    isarray: ^2.0.5
+    object-is: ^1.1.5
+    object-keys: ^1.1.1
+    object.assign: ^4.1.4
+    regexp.prototype.flags: ^1.4.3
+    side-channel: ^1.0.4
+    which-boxed-primitive: ^1.0.2
+    which-collection: ^1.0.1
+    which-typed-array: ^1.1.9
+  checksum: 46a34509d2766d6c6dc5aec4756089cf0cc137e46787e91f08f1ee0bb570d874f19f0493146907df0cf18aed4a7b4b50f6f62c899240a76c323f057528b122e3
+  languageName: node
+  linkType: hard
+
 "deep-extend@npm:^0.6.0":
   version: 0.6.0
   resolution: "deep-extend@npm:0.6.0"
@@ -4328,6 +4412,13 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 005eb283caef57fc1adec4d5df4dd49189b628f2f575af45decb210e04d634459e3f1ee64f18b41e2dcf200c844bc1d9279d80807e686a30d69a4756151ad248
   languageName: node
   linkType: hard
 
@@ -4513,6 +4604,23 @@ __metadata:
     unbox-primitive: ^1.0.2
     which-typed-array: ^1.1.9
   checksum: 23ff60d42d17a55d150e7bcedbdb065d4077a8b98c436e0e2e1ef4dd532a6d78a56028673de0bd8ed464a43c46ba781c50d9af429b6a17e44dbd14c7d7fb7926
+  languageName: node
+  linkType: hard
+
+"es-get-iterator@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "es-get-iterator@npm:1.1.3"
+  dependencies:
+    call-bind: ^1.0.2
+    get-intrinsic: ^1.1.3
+    has-symbols: ^1.0.3
+    is-arguments: ^1.1.1
+    is-map: ^2.0.2
+    is-set: ^2.0.2
+    is-string: ^1.0.7
+    isarray: ^2.0.5
+    stop-iteration-iterator: ^1.0.0
+  checksum: 8fa118da42667a01a7c7529f8a8cca514feeff243feec1ce0bb73baaa3514560bd09d2b3438873cf8a5aaec5d52da248131de153b28e2638a061b6e4df13267d
   languageName: node
   linkType: hard
 
@@ -6182,6 +6290,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-arguments@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "is-arguments@npm:1.1.1"
+  dependencies:
+    call-bind: ^1.0.2
+    has-tostringtag: ^1.0.0
+  checksum: 7f02700ec2171b691ef3e4d0e3e6c0ba408e8434368504bb593d0d7c891c0dbfda6d19d30808b904a6cb1929bca648c061ba438c39f296c2a8ca083229c49f27
+  languageName: node
+  linkType: hard
+
 "is-array-buffer@npm:^3.0.1":
   version: 3.0.1
   resolution: "is-array-buffer@npm:3.0.1"
@@ -6264,7 +6382,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-date-object@npm:^1.0.1":
+"is-date-object@npm:^1.0.1, is-date-object@npm:^1.0.5":
   version: 1.0.5
   resolution: "is-date-object@npm:1.0.5"
   dependencies:
@@ -6323,6 +6441,13 @@ __metadata:
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
   checksum: 93a32f01940220532e5948538699ad610d5924ac86093fcee83022252b363eb0cc99ba53ab084a04e4fb62bf7b5731f55496257a4c38adf87af9c4d352c71c35
+  languageName: node
+  linkType: hard
+
+"is-map@npm:^2.0.1, is-map@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "is-map@npm:2.0.2"
+  checksum: ace3d0ecd667bbdefdb1852de601268f67f2db725624b1958f279316e13fecb8fa7df91fd60f690d7417b4ec180712f5a7ee967008e27c65cfd475cc84337728
   languageName: node
   linkType: hard
 
@@ -6410,6 +6535,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-set@npm:^2.0.1, is-set@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "is-set@npm:2.0.2"
+  checksum: b64343faf45e9387b97a6fd32be632ee7b269bd8183701f3b3f5b71a7cf00d04450ed8669d0bd08753e08b968beda96fca73a10fd0ff56a32603f64deba55a57
+  languageName: node
+  linkType: hard
+
 "is-shared-array-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "is-shared-array-buffer@npm:1.0.2"
@@ -6480,6 +6612,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-weakmap@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "is-weakmap@npm:2.0.1"
+  checksum: 1222bb7e90c32bdb949226e66d26cb7bce12e1e28e3e1b40bfa6b390ba3e08192a8664a703dff2a00a84825f4e022f9cd58c4599ff9981ab72b1d69479f4f7f6
+  languageName: node
+  linkType: hard
+
 "is-weakref@npm:^1.0.2":
   version: 1.0.2
   resolution: "is-weakref@npm:1.0.2"
@@ -6489,12 +6628,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-weakset@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "is-weakset@npm:2.0.2"
+  dependencies:
+    call-bind: ^1.0.2
+    get-intrinsic: ^1.1.1
+  checksum: 5d8698d1fa599a0635d7ca85be9c26d547b317ed8fd83fc75f03efbe75d50001b5eececb1e9971de85fcde84f69ae6f8346bc92d20d55d46201d328e4c74a367
+  languageName: node
+  linkType: hard
+
 "is-wsl@npm:^2.2.0":
   version: 2.2.0
   resolution: "is-wsl@npm:2.2.0"
   dependencies:
     is-docker: ^2.0.0
   checksum: 20849846ae414997d290b75e16868e5261e86ff5047f104027026fd61d8b5a9b0b3ade16239f35e1a067b3c7cc02f70183cb661010ed16f4b6c7c93dad1b19d8
+  languageName: node
+  linkType: hard
+
+"isarray@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "isarray@npm:2.0.5"
+  checksum: bd5bbe4104438c4196ba58a54650116007fa0262eccef13a4c55b2e09a5b36b59f1e75b9fcc49883dd9d4953892e6fc007eef9e9155648ceea036e184b0f930a
   languageName: node
   linkType: hard
 
@@ -7777,6 +7933,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 1ee98b4580246fd90dd54da6e346fb1caefcf05f677c686d9af237a157fdea3fd7c83a4bc58f858cd5b10a34d27afe0fdcbd0505a47e0590726a873dc8b8f65d
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^3.0.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
@@ -8647,6 +8812,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-is@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "object-is@npm:1.1.5"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.3
+  checksum: 989b18c4cba258a6b74dc1d74a41805c1a1425bce29f6cabb50dcb1a6a651ea9104a1b07046739a49a5bb1bc49727bcb00efd5c55f932f6ea04ec8927a7901fe
+  languageName: node
+  linkType: hard
+
 "object-keys@npm:^1.1.1":
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
@@ -9204,6 +9379,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: ^5.0.1
+    ansi-styles: ^5.0.0
+    react-is: ^17.0.1
+  checksum: cf610cffcb793885d16f184a62162f2dd0df31642d9a18edf4ca298e909a8fe80bdbf556d5c9573992c102ce8bf948691da91bf9739bee0ffb6e79c8a8a6e088
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^29.5.0":
   version: 29.5.0
   resolution: "pretty-format@npm:29.5.0"
@@ -9410,6 +9596,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^17.0.1":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^18.0.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
@@ -9580,6 +9773,13 @@ __metadata:
   version: 0.1.13
   resolution: "reflect-metadata@npm:0.1.13"
   checksum: 798d379a7b6f6455501145419505c97dd11cbc23857a386add2b9ef15963ccf15a48d9d15507afe01d4cd74116df8a213247200bac00320bd7c11ddeaa5e8fb4
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.13.11":
+  version: 0.13.11
+  resolution: "regenerator-runtime@npm:0.13.11"
+  checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
   languageName: node
   linkType: hard
 
@@ -10150,6 +10350,8 @@ __metadata:
     "@semantic-release/git": ^10.0.1
     "@swc/core": ^1.3.46
     "@swc/jest": ^0.2.24
+    "@testing-library/dom": ^9.2.0
+    "@testing-library/user-event": ^14.4.3
     "@types/node": ^18.15.11
     "@types/semantic-release": ^20.0.1
     "@types/ssri": ^7.1.1
@@ -10410,6 +10612,15 @@ __metadata:
     "@hotwired/stimulus": ">= 3"
     hotkeys-js: ">= 3"
   checksum: 99a0b8f2f89564ee8cb5aa3874e7e0e15ac6e6dcd0f327dc85fc504fd384248629d1730490d1df78489190cc061a56e7238bfef15690459ee0d02d0004de609c
+  languageName: node
+  linkType: hard
+
+"stop-iteration-iterator@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "stop-iteration-iterator@npm:1.0.0"
+  dependencies:
+    internal-slot: ^1.0.4
+  checksum: d04173690b2efa40e24ab70e5e51a3ff31d56d699550cfad084104ab3381390daccb36652b25755e420245f3b0737de66c1879eaa2a8d4fc0a78f9bf892fcb42
   languageName: node
   linkType: hard
 
@@ -11685,6 +11896,18 @@ __metadata:
     is-string: ^1.0.5
     is-symbol: ^1.0.3
   checksum: 53ce774c7379071729533922adcca47220228405e1895f26673bbd71bdf7fb09bee38c1d6399395927c6289476b5ae0629863427fd151491b71c4b6cb04f3a5e
+  languageName: node
+  linkType: hard
+
+"which-collection@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "which-collection@npm:1.0.1"
+  dependencies:
+    is-map: ^2.0.1
+    is-set: ^2.0.1
+    is-weakmap: ^2.0.1
+    is-weakset: ^2.0.1
+  checksum: c815bbd163107ef9cb84f135e6f34453eaf4cca994e7ba85ddb0d27cea724c623fae2a473ceccfd5549c53cc65a5d82692de418166df3f858e1e5dc60818581c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
My previous refactor introduced a bug where stopPropagation was not properly bound. Fix this and use pointer events evenstead of mouse events, and add tests covering most of the histogram controller.
