### PR TITLE
fix(connected-users): create usercard DOM just once

### DIFF
--- a/scripts/connected-users/src/users/classes.ts
+++ b/scripts/connected-users/src/users/classes.ts
@@ -34,6 +34,17 @@ export abstract class User {
   }
 
   abstract toHTML(): string
+
+  private cachedNode: HTMLElement | null = null
+
+  get node(): HTMLElement {
+    if (this.cachedNode === null) {
+      const node = document.createElement('div')
+      node.innerHTML = this.toHTML()
+      this.cachedNode = node.firstElementChild as HTMLElement
+    }
+    return this.cachedNode
+  }
 }
 
 /* subset of https://api.stackexchange.com/docs/types/user */

--- a/scripts/connected-users/src/users/controller.ts
+++ b/scripts/connected-users/src/users/controller.ts
@@ -56,8 +56,8 @@ export class UserListController extends Stacks.StacksController {
             : null
         const existingCard =
           userRow.querySelector<HTMLDivElement>('.s-user-card')
-        if (existingCard) existingCard.outerHTML = user.toHTML()
-        else userRow.innerHTML = user.toHTML()
+        if (existingCard) existingCard.replaceWith(user.node)
+        else userRow.replaceChildren(user.node)
         const newCard = userRow.querySelector('.s-user-card')
         newCard?.classList.add(...this.userCardClasses)
         if (firstChild) {

--- a/scripts/connected-users/test/users/__snapshots__/classes.test.ts.snap
+++ b/scripts/connected-users/test/users/__snapshots__/classes.test.ts.snap
@@ -1,3344 +1,5496 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Deleted user can rendered to HTML 1`] = `
-"
-      <div class="s-user-card s-user-card__deleted">
-        <a href="/users/42" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <span class="anonymous-gravatar s-avatar--image"></span>
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42" class="s-user-card--link"
-            >user42</a
-          >
-        </div>
-      </div>
-    "
+<div
+  class="s-user-card s-user-card__deleted"
+>
+  
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42"
+  >
+    
+          
+    <span
+      class="anonymous-gravatar s-avatar--image"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42"
+    >
+      user42
+    </a>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1"
+      >
+        
               1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 1,234"
+      >
+        
               1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 17,424"
+      >
+        
               17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__moderator s-badge__xs"
+      >
+        Mod
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+       
+      <span
+        class="s-badge s-badge__admin s-badge__xs"
+      >
+        Admin
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;
 
 exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
+<div
+  class="s-user-card"
+  data-uid="42"
+>
+   
+        
+  <a
+    class="s-avatar s-avatar__32 s-user-card--avatar"
+    href="https://othersite.example.com/users/42/test-user"
+  >
+    
+          
+    <img
+      class="s-avatar--image"
+      src="https://images.example.com/test-user.png"
+    />
+    
+        
+  </a>
+  
+        
+  <div
+    class="s-user-card--info"
+  >
+    
+          
+    <a
+      class="s-user-card--link"
+      href="https://othersite.example.com/users/42/test-user"
+    >
+      Test User &lt;script&gt;alert("XSS")&lt;/script&gt; 
+      <span
+        class="s-badge s-badge__staff s-badge__xs"
+      >
+        Staff
+      </span>
+    </a>
+    
+          
+    <ul
+      class="s-user-card--awards"
+    >
+      
+            
+      <li
+        class="s-user-card--rep"
+        title="reputation score 4,321,432"
+      >
+        
               4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 1234, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 17424, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://example.com/users/42/test-user, reputation 4321432, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1"
-            >
-              1
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 1234, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 1,234"
-            >
-              1,234
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 17424, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 17,424"
-            >
-              17.4k
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type moderator, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type moderator, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__moderator s-badge__xs">Mod</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type registered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type registered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type team_admin, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type team_admin, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span> <span class="s-badge s-badge__admin s-badge__xs">Admin</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type unregistered, and is_employee false 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; </a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
-`;
-
-exports[`Users are rendered to HTML reflecting link https://othersite.example.com/users/42/test-user, reputation 4321432, user type unregistered, and is_employee true 1`] = `
-"
-      <div class="s-user-card" data-uid="42"> 
-        <a href="https://othersite.example.com/users/42/test-user" class="s-avatar s-avatar__32 s-user-card--avatar">
-          <img class="s-avatar--image" src="https://images.example.com/test-user.png" />
-        </a>
-        <div class="s-user-card--info">
-          <a href="https://othersite.example.com/users/42/test-user" class="s-user-card--link"
-            >Test User &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt; <span class="s-badge s-badge__staff s-badge__xs">Staff</span></a
-          >
-          <ul class="s-user-card--awards">
-            <li
-              class="s-user-card--rep"
-              title="reputation score 4,321,432"
-            >
-              4.32m
-            </li>
-            <li class="s-award-bling s-award-bling__gold">1</li>
-            <li class="s-award-bling s-award-bling__silver">2</li>
-            <li class="s-award-bling s-award-bling__bronze">3</li>
-          </ul>
-        </div>
-      </div>
-    "
+            
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__gold"
+      >
+        1
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__silver"
+      >
+        2
+      </li>
+      
+            
+      <li
+        class="s-award-bling s-award-bling__bronze"
+      >
+        3
+      </li>
+      
+          
+    </ul>
+    
+        
+  </div>
+  
+      
+</div>
 `;

--- a/scripts/connected-users/test/users/classes.test.ts
+++ b/scripts/connected-users/test/users/classes.test.ts
@@ -38,12 +38,12 @@ describe('Users are rendered to HTML', () => {
         user_type: userType,
         is_employee: isEmployee,
       })
-      expect(user.toHTML()).toMatchSnapshot()
+      expect(user.node).toMatchSnapshot()
     }
   )
 })
 
 test('Deleted user can rendered to HTML', () => {
   const deletedUser = new DeletedUser(42)
-  expect(deletedUser.toHTML()).toMatchSnapshot()
+  expect(deletedUser.node).toMatchSnapshot()
 })


### PR DESCRIPTION
Don't have the browser parse the HTML into DOM nodes each time, cache
the DOM tree on the user instance. This does mean you can only insert it
into a single location, but that's the case here anyway.
